### PR TITLE
Add new input "end-pipeline-step-before-task-finish" to terminate the pipeline step if the Fargate task has not finished executing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Will pass the following command to the container on the AWS ECS Fargate task:
 | override-container-environment | Add or override existing environment variables if `override-container` is passed. Provide one per line in key=value format. | `false` |  |
 | tail-logs | If set to true, will try to extract the logConfiguration for the first container in the task definition. If `override-container` is passed, it will extract the logConfiguration from that container. Tailing logs is only possible if the provided container uses the `awslogs` logDriver. | `false` | true |
 | task-stopped-wait-for-max-attempts | How many times to check if the task is stopped before failing the action. The delay between each check is 6 seconds. | `false` | 100 |
+| end-pipeline-step-before-task-finish | Terminate the pipeline step if the Fargate task has not finished executing. | `false` | `false` |
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,12 @@ inputs:
     required: false
     default: 100
 
+  end-pipeline-step-before-task-finish:
+    description: >-
+      Terminate the pipeline step if the Fargate task has not finished executing.
+    required: false
+    default: 'false'
+
 outputs:
   task-arn:
     description: 'The full ARN for the task that was ran.'


### PR DESCRIPTION
… pipeline step if the Fargate task has not finished executing.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves
Add new input "end-pipeline-step-before-task-finish" to terminate the pipeline step if the Fargate task has not finished executing
...

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [ ] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
