### PR TITLE
Upgrade and features

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <!-- action-docs-description -->
 ## Description
 
-Run an AWS ECS Fargate task and execute a custom command. See the log output of the command that is executed.
+Run an AWS ECS Fargate task and execute a custom commands. See the log output of the commands.
 <!-- action-docs-description -->
 
 ### Details
@@ -42,6 +42,10 @@ This action is great for executing migrations or other pre/post deployment steps
     override-container-environment: |
       AWS_REGION=us-east-1
       FOO=baz
+
+    task-wait-until-stopped: true
+    task-start-max-wait-time: 120
+    task-stopped-max-wait-time: 300
 ```
 
 #### Minimal example
@@ -97,7 +101,9 @@ Will pass the following command to the container on the AWS ECS Fargate task:
 | override-container-command | The command to run on the container if `override-container` is passed. | `false` |  |
 | override-container-environment | Add or override existing environment variables if `override-container` is passed. Provide one per line in key=value format. | `false` |  |
 | tail-logs | If set to true, will try to extract the logConfiguration for the first container in the task definition. If `override-container` is passed, it will extract the logConfiguration from that container. Tailing logs is only possible if the provided container uses the `awslogs` logDriver. | `false` | true |
-| task-stopped-wait-for-max-attempts | How many times to check if the task is stopped before failing the action. The delay between each check is 6 seconds. | `false` | 100 |
+| task-wait-until-stopped | Whether to wait for the task to stop before finishing the action. If set to false, the action will finish immediately after the task reaches the `RUNNING` state (fire and forget). | `false` | true |
+| task-start-max-wait-time | How long to wait for the task to start (i.e. reach the `RUNNING` state) in seconds. If the task does not start within this time, the pipeline will fail. | `false` | 120 |
+| task-stopped-max-wait-time | How long to wait for the task to stop (i.e. reach the `STOPPED` state) in seconds. The task will not be canceled after this time, the pipeline will just be marked as failed. | `false` | 300 |
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->
@@ -107,7 +113,7 @@ Will pass the following command to the container on the AWS ECS Fargate task:
 | --- | --- |
 | task-arn | The full ARN for the task that was ran. |
 | task-id | The ID for the task that was ran. |
-| log-output | The log output of the task that was ran, if `tail-logs` was set to true. |
+| log-output | The log output of the task that was ran, if `tail-logs` and `task-wait-until-stopped` are set to true. |
 <!-- action-docs-outputs -->
 
 <!-- action-docs-runs -->

--- a/action.yml
+++ b/action.yml
@@ -60,11 +60,26 @@ inputs:
     required: false
     default: 'true'
 
-  task-stopped-wait-for-max-attempts:
+  task-wait-until-stopped:
     description: >-
-      How many times to check if the task is stopped before failing the action. The delay between each check is 6 seconds.
+      Whether to wait for the task to stop before finishing the action. If set to false, the action will finish
+      immediately after the task reaches the `RUNNING` state (fire and forget).
     required: false
-    default: 100
+    default: 'true'
+
+  task-start-max-wait-time:
+    description: >-
+      How long to wait for the task to start (i.e. reach the `RUNNING` state) in seconds. If the task does not start
+      within this time, the pipeline will fail.
+    required: false
+    default: 120
+
+  task-stopped-max-wait-time:
+    description: >-
+      How long to wait for the task to stop (i.e. reach the `STOPPED` state) in seconds. The task will not be canceled
+      after this time, the pipeline will just be marked as failed.
+    required: false
+    default: 300
 
 outputs:
   task-arn:
@@ -72,7 +87,7 @@ outputs:
   task-id:
     description: 'The ID for the task that was ran.'
   log-output:
-    description: 'The log output of the task that was ran, if `tail-logs` was set to true.'
+    description: 'The log output of the task that was ran, if `tail-logs` and `task-wait-until-stopped` are set to true.'
 
 runs:
   using: 'node20'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,12 +1688,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -2359,9 +2359,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"


### PR DESCRIPTION
* Add options to skip waiting for task to finish
* Change max wait time variables

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

* Upgrade AWS SDK to Version 3
* Fix Dependabot findings
* Replace `task-stopped-wait-for-max-attempts` with `task-stopped-max-wait-time`
* Add new vars `task-wait-until-stopped` and `task-start-max-wait-time`

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [ ] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
