### PR TITLE
Use linear backoff on the SDK v3 Waiter due to failure rate for short…

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Will pass the following command to the container on the AWS ECS Fargate task:
 | task-wait-until-stopped | Whether to wait for the task to stop before finishing the action. If set to false, the action will finish immediately after the task reaches the `RUNNING` state (fire and forget). | `false` | true |
 | task-start-max-wait-time | How long to wait for the task to start (i.e. reach the `RUNNING` state) in seconds. If the task does not start within this time, the pipeline will fail. | `false` | 120 |
 | task-stopped-max-wait-time | How long to wait for the task to stop (i.e. reach the `STOPPED` state) in seconds. The task will not be canceled after this time, the pipeline will just be marked as failed. | `false` | 300 |
+| task-check-state-delay | How long to wait between each AWS API call to check the current state of the task in seconds. This is useful to avoid running into AWS rate limits. **However**, setting this too high might cause the Action to miss the time-window your task is in the "RUNNING" state (if you task is very short lived) and can cause the action to fail. | `false` | 6 |
 <!-- action-docs-inputs -->
 
 <!-- action-docs-outputs -->

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,14 @@ inputs:
     required: false
     default: 300
 
+  task-check-state-delay:
+    description: >-
+      How long to wait between each AWS API call to check the current state of the task in seconds. This is useful to
+      avoid running into AWS rate limits. **However**, setting this too high might cause the Action to miss the time-window
+      your task is in the "RUNNING" state (if you task is very short lived) and can cause the action to fail.
+    required: false
+    default: 6
+
 outputs:
   task-arn:
     description: 'The full ARN for the task that was ran.'

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ const main = async () => {
         const taskWaitUntilStopped = core.getBooleanInput('task-wait-until-stopped', {required: false});
         const taskStartMaxWaitTime = parseInt(core.getInput('task-start-max-wait-time', {required: false}));
         const taskStoppedMaxWaitTime = parseInt(core.getInput('task-stopped-max-wait-time', {required: false}));
+        const taskCheckStateDelay = parseInt(core.getInput('task-check-state-delay', {required: false}));
 
         // Build Task parameters
         const taskRequestParams = {
@@ -110,6 +111,8 @@ const main = async () => {
             await waitUntilTasksRunning({
                 client: ecs,
                 maxWaitTime: taskStartMaxWaitTime,
+                maxDelay: taskCheckStateDelay,
+                minDelay: taskCheckStateDelay,
             }, {cluster, tasks: [taskArn]});
         } catch (error) {
             core.setFailed(`Task did not start successfully. Error: ${error.name}. State: ${error.state}.`);
@@ -181,6 +184,8 @@ const main = async () => {
             await waitUntilTasksStopped({
                 client: ecs,
                 maxWaitTime: taskStoppedMaxWaitTime,
+                maxDelay: taskCheckStateDelay,
+                minDelay: taskCheckStateDelay,
             }, {
                 cluster,
                 tasks: [taskArn],


### PR DESCRIPTION
… running tasks

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->

## What it solves

Since v3 the AWS SDK uses a Waiter with exponential back-off and jitter to check for the state of the task. This is in general a good thing, as it reduces the load on the AWS API and is more efficient. 

**HOWEVER:**
If  the task that is started is short-lived, the Waiter might not be able to catch the task in the "RUNNING" state at all, because the potential back-off method will increase the delay to a value that is too high.

The Waiter will randomly catch it in the "STOPPED" state and throw an error as the exit code is not checked in the waiter.  To combat this we use the old behavior, we will go back to use the linear back-off by setting both delay values to the same value.

See: https://aws.amazon.com/blogs/developer/waiters-in-modular-aws-sdk-for-javascript/

## Readiness Checklist

### Author/Contributor
- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] Pull request title is brief and descriptive (for a changelog entry)

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, or `enhancement`
- [ ] Label as `bump:patch`, `bump:minor`, or `bump:major` if this PR should create a new release
